### PR TITLE
Remove warning message for Capybara(>1.0.0)

### DIFF
--- a/lib/combustion.rb
+++ b/lib/combustion.rb
@@ -17,8 +17,24 @@ module Combustion
     end
 
     RSpec.configure do |config|
-      config.include(Capybara::DSL) if defined?(Capybara)
+      if defined?(Capybara::RSpecMatchers)
+        config.include Capybara::RSpecMatchers, :type => :view
+        config.include Capybara::RSpecMatchers, :type => :helper
+        config.include Capybara::RSpecMatchers, :type => :mailer
+        config.include Capybara::RSpecMatchers, :type => :controller
+      end
 
+      if defined?(Capybara::DSL)
+        config.include Capybara::DSL, :type => :controller
+      end
+
+      unless defined?(Capybara::RSpecMatchers) || defined?(Capybara::DSL)
+        if defined?(Capybara)
+          config.include Capybara, :type => :request
+          config.include Capybara, :type => :controller
+        end
+      end
+      
       config.include(Combustion::Application.routes.url_helpers)
       config.include(Combustion::Application.routes.mounted_helpers)
     end if defined?(RSpec) && RSpec.respond_to?(:configure)


### PR DESCRIPTION
It is quite annoying as it will show the warning message for every spec I have.

I found this code from:

https://github.com/rspec/rspec-rails/blob/master/lib/rspec/rails/vendor/capybara.rb
