### PR TITLE
Update README to specify test environment.

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -11,14 +11,14 @@ Get the gem into either your gemspec or your Gemfile, depending on how you manag
 <pre><code># gemspec
 gem.add_development_dependency 'combustion', '~> 0.3.1'
 # Gemfile
-gem 'combustion', '~> 0.3.1`, :group => :development</code></pre>
+gem 'combustion', '~> 0.3.1`, :group => :test</code></pre>
 
 In your @spec_helper.rb@, get Combustion to set itself up - which has to happen before you introduce @rspec/rails@ and - if being used - @capybara/rspec@. Here's an example within context:
 
 <pre><code>require 'rubygems'
 require 'bundler'
 
-Bundler.require :default, :development
+Bundler.require :default, :test
 
 require 'capybara/rspec'
 


### PR DESCRIPTION
I was attempting to resolve a schema loading issue I was running into, and ran into issues getting Combustion.initialize! to run since my bundler require was pointing to development rather than test as it should be for specs.

I ended up not following through with my schema loading issue since I didn't see an easy way to make it work.  I'd like to have the schema loaded before the models are initialized if possible.  The ActiveRecord connection wasn't being made before the models got loaded though.
