### PR TITLE
Update application.rb to use Action*::Railtie

### DIFF
--- a/lib/combustion/application.rb
+++ b/lib/combustion/application.rb
@@ -16,13 +16,13 @@ class Combustion::Application < Rails::Application
   def self.configure_for_combustion
     config.root = File.expand_path File.join(Dir.pwd, Combustion.path)
 
-    if defined?(ActionController) && defined?(ActionController::Engine)
+    if defined?(ActionController) && defined?(ActionController::Railtie)
       config.action_dispatch.show_exceptions            = false
       config.action_controller.perform_caching          = false
       config.action_controller.allow_forgery_protection = false
     end
 
-    if defined?(ActionMailer) && defined?(ActionMailer::Engine)
+    if defined?(ActionMailer) && defined?(ActionMailer::Railtie)
       config.action_mailer.delivery_method     = :test
       config.action_mailer.default_url_options = {:host => 'www.example.com'}
     end


### PR DESCRIPTION
I'm not sure where ActionController::Engine and ActionMailer::Engine came from -- I don't see them in the Rails release-3.0, release-3.1 or release-3.2 branches. I suspect Railtie is the right constant to use instead.
