### PR TITLE
Place class definitions inside module Combustion.

### DIFF
--- a/lib/combustion/application.rb
+++ b/lib/combustion/application.rb
@@ -1,34 +1,36 @@
 Rails.env = 'test'
 
-class Combustion::Application < Rails::Application
-  # Core Settings
-  config.cache_classes               = true
-  config.whiny_nils                  = true
-  config.consider_all_requests_local = true
-  config.secret_token                = Digest::SHA1.hexdigest Time.now.to_s
+module Combustion
+  class Application < Rails::Application
+    # Core Settings
+    config.cache_classes               = true
+    config.whiny_nils                  = true
+    config.consider_all_requests_local = true
+    config.secret_token                = Digest::SHA1.hexdigest Time.now.to_s
 
-  # ActiveSupport Settings
-  config.active_support.deprecation = :stderr
+    # ActiveSupport Settings
+    config.active_support.deprecation = :stderr
 
-  # Some settings we're not sure if we want, so let's not load them by default.
-  # Instead, wait for this method to be invoked (to get around load-order
-  # complications).
-  def self.configure_for_combustion
-    config.root = File.expand_path File.join(Dir.pwd, Combustion.path)
+    # Some settings we're not sure if we want, so let's not load them by default.
+    # Instead, wait for this method to be invoked (to get around load-order
+    # complications).
+    def self.configure_for_combustion
+      config.root = File.expand_path File.join(Dir.pwd, Combustion.path)
 
-    if defined?(ActionController) && defined?(ActionController::Railtie)
-      config.action_dispatch.show_exceptions            = false
-      config.action_controller.perform_caching          = false
-      config.action_controller.allow_forgery_protection = false
-    end
+      if defined?(ActionController) && defined?(ActionController::Railtie)
+        config.action_dispatch.show_exceptions            = false
+        config.action_controller.perform_caching          = false
+        config.action_controller.allow_forgery_protection = false
+      end
 
-    if defined?(ActionMailer) && defined?(ActionMailer::Railtie)
-      config.action_mailer.delivery_method     = :test
-      config.action_mailer.default_url_options = {:host => 'www.example.com'}
-    end
+      if defined?(ActionMailer) && defined?(ActionMailer::Railtie)
+        config.action_mailer.delivery_method     = :test
+        config.action_mailer.default_url_options = {:host => 'www.example.com'}
+      end
 
-    if defined?(Sprockets)
-      config.assets.enabled = true
+      if defined?(Sprockets)
+        config.assets.enabled = true
+      end
     end
   end
 end

--- a/lib/combustion/database.rb
+++ b/lib/combustion/database.rb
@@ -1,166 +1,168 @@
-class Combustion::Database
-  def self.setup
-    silence_stream(STDOUT) do
-      reset_database
-      load_schema
-      migrate
-    end
-  end
-
-  def self.reset_database
-    abcs = ActiveRecord::Base.configurations
-    case abcs['test']['adapter']
-    when /mysql/
-      ActiveRecord::Base.establish_connection(:test)
-      ActiveRecord::Base.connection.recreate_database(abcs['test']['database'],
-        mysql_creation_options(abcs['test']))
-      ActiveRecord::Base.establish_connection(:test)
-    when /postgresql/
-      ActiveRecord::Base.clear_active_connections!
-      drop_database(abcs['test'])
-      create_database(abcs['test'])
-    when /sqlite/
-      drop_database(abcs['test'])
-      create_database(abcs['test'])
-    when 'sqlserver'
-      test = abcs.deep_dup['test']
-      test_database = test['database']
-      test['database'] = 'master'
-      ActiveRecord::Base.establish_connection(test)
-      ActiveRecord::Base.connection.recreate_database!(test_database)
-    when "oci", "oracle"
-      ActiveRecord::Base.establish_connection(:test)
-      ActiveRecord::Base.connection.structure_drop.split(";\n\n").each do |ddl|
-        ActiveRecord::Base.connection.execute(ddl)
+module Combustion
+  class Database
+    def self.setup
+      silence_stream(STDOUT) do
+        reset_database
+        load_schema
+        migrate
       end
-    when 'firebird'
-      ActiveRecord::Base.establish_connection(:test)
-      ActiveRecord::Base.connection.recreate_database!
-    else
-      raise "Cannot reset databases for '#{abcs['test']['adapter']}'"
     end
-  end
 
-  def self.load_schema
-    case Combustion.schema_format
-    when :ruby
-      load Rails.root.join('db', 'schema.rb')
-    when :sql
-      ActiveRecord::Base.connection.execute(
-        File.read(Rails.root.join('db', 'structure.sql'))
-      )
-    else
-      raise "Unknown schema format: #{Combustion.schema_format}"
+    def self.reset_database
+      abcs = ActiveRecord::Base.configurations
+      case abcs['test']['adapter']
+      when /mysql/
+        ActiveRecord::Base.establish_connection(:test)
+        ActiveRecord::Base.connection.recreate_database(abcs['test']['database'],
+          mysql_creation_options(abcs['test']))
+        ActiveRecord::Base.establish_connection(:test)
+      when /postgresql/
+        ActiveRecord::Base.clear_active_connections!
+        drop_database(abcs['test'])
+        create_database(abcs['test'])
+      when /sqlite/
+        drop_database(abcs['test'])
+        create_database(abcs['test'])
+      when 'sqlserver'
+        test = abcs.deep_dup['test']
+        test_database = test['database']
+        test['database'] = 'master'
+        ActiveRecord::Base.establish_connection(test)
+        ActiveRecord::Base.connection.recreate_database!(test_database)
+      when "oci", "oracle"
+        ActiveRecord::Base.establish_connection(:test)
+        ActiveRecord::Base.connection.structure_drop.split(";\n\n").each do |ddl|
+          ActiveRecord::Base.connection.execute(ddl)
+        end
+      when 'firebird'
+        ActiveRecord::Base.establish_connection(:test)
+        ActiveRecord::Base.connection.recreate_database!
+      else
+        raise "Cannot reset databases for '#{abcs['test']['adapter']}'"
+      end
     end
-  end
 
-  def self.migrate
-    migrator = ActiveRecord::Migrator
-    paths    = Array('db/migrate/')
-
-    if migrator.respond_to?(:migrations_paths)
-      paths = migrator.migrations_paths
+    def self.load_schema
+      case Combustion.schema_format
+      when :ruby
+        load Rails.root.join('db', 'schema.rb')
+      when :sql
+        ActiveRecord::Base.connection.execute(
+          File.read(Rails.root.join('db', 'structure.sql'))
+        )
+      else
+        raise "Unknown schema format: #{Combustion.schema_format}"
+      end
     end
-    # Append the migrations inside the internal app's db/migrate directory
-    paths << File.join(Rails.root, 'db/migrate')
-    migrator.migrate paths, nil
-  end
 
-  private
+    def self.migrate
+      migrator = ActiveRecord::Migrator
+      paths    = Array('db/migrate/')
 
-  def self.create_database(config)
-    begin
-      if config['adapter'] =~ /sqlite/
-        if File.exist?(config['database'])
-          $stderr.puts "#{config['database']} already exists"
+      if migrator.respond_to?(:migrations_paths)
+        paths = migrator.migrations_paths
+      end
+      # Append the migrations inside the internal app's db/migrate directory
+      paths << File.join(Rails.root, 'db/migrate')
+      migrator.migrate paths, nil
+    end
+
+    private
+
+    def self.create_database(config)
+      begin
+        if config['adapter'] =~ /sqlite/
+          if File.exist?(config['database'])
+            $stderr.puts "#{config['database']} already exists"
+          else
+            begin
+              # Create the SQLite database
+              ActiveRecord::Base.establish_connection(config)
+              ActiveRecord::Base.connection
+            rescue Exception => e
+              $stderr.puts e, *(e.backtrace)
+              $stderr.puts "Couldn't create database for #{config.inspect}"
+            end
+          end
+          return # Skip the else clause of begin/rescue
         else
+          ActiveRecord::Base.establish_connection(config)
+          ActiveRecord::Base.connection
+        end
+      rescue
+        case config['adapter']
+        when /^(jdbc)?mysql/
+          if config['adapter'] =~ /jdbc/
+            #FIXME After Jdbcmysql gives this class
+            require 'active_record/railties/jdbcmysql_error'
+            error_class = ArJdbcMySQL::Error
+          else
+            error_class = config['adapter'] =~ /mysql2/ ? Mysql2::Error : Mysql::Error
+          end
+          access_denied_error = 1045
           begin
-            # Create the SQLite database
+            ActiveRecord::Base.establish_connection(config.merge('database' => nil))
+            ActiveRecord::Base.connection.create_database(config['database'], mysql_creation_options(config))
             ActiveRecord::Base.establish_connection(config)
-            ActiveRecord::Base.connection
+          rescue error_class => sqlerr
+            if sqlerr.errno == access_denied_error
+              print "#{sqlerr.error}. \nPlease provide the root password for your mysql installation\n>"
+              root_password = $stdin.gets.strip
+              grant_statement = "GRANT ALL PRIVILEGES ON #{config['database']}.* " \
+                "TO '#{config['username']}'@'localhost' " \
+                "IDENTIFIED BY '#{config['password']}' WITH GRANT OPTION;"
+              ActiveRecord::Base.establish_connection(config.merge(
+                  'database' => nil, 'username' => 'root', 'password' => root_password))
+              ActiveRecord::Base.connection.create_database(config['database'], mysql_creation_options(config))
+              ActiveRecord::Base.connection.execute grant_statement
+              ActiveRecord::Base.establish_connection(config)
+            else
+              $stderr.puts sqlerr.error
+              $stderr.puts "Couldn't create database for #{config.inspect}, charset: #{config['charset'] || @charset}, collation: #{config['collation'] || @collation}"
+              $stderr.puts "(if you set the charset manually, make sure you have a matching collation)" if config['charset']
+            end
+          end
+        when /^(jdbc)?postgresql$/
+          @encoding = config['encoding'] || ENV['CHARSET'] || 'utf8'
+          begin
+            ActiveRecord::Base.establish_connection(config.merge('database' => 'postgres', 'schema_search_path' => 'public'))
+            ActiveRecord::Base.connection.create_database(config['database'], config.merge('encoding' => @encoding))
+            ActiveRecord::Base.establish_connection(config)
           rescue Exception => e
             $stderr.puts e, *(e.backtrace)
             $stderr.puts "Couldn't create database for #{config.inspect}"
           end
         end
-        return # Skip the else clause of begin/rescue
       else
-        ActiveRecord::Base.establish_connection(config)
-        ActiveRecord::Base.connection
+        $stderr.puts "#{config['database']} already exists"
       end
-    rescue
+    end
+
+    def self.drop_database(config)
       case config['adapter']
       when /^(jdbc)?mysql/
-        if config['adapter'] =~ /jdbc/
-          #FIXME After Jdbcmysql gives this class
-          require 'active_record/railties/jdbcmysql_error'
-          error_class = ArJdbcMySQL::Error
-        else
-          error_class = config['adapter'] =~ /mysql2/ ? Mysql2::Error : Mysql::Error
-        end
-        access_denied_error = 1045
-        begin
-          ActiveRecord::Base.establish_connection(config.merge('database' => nil))
-          ActiveRecord::Base.connection.create_database(config['database'], mysql_creation_options(config))
-          ActiveRecord::Base.establish_connection(config)
-        rescue error_class => sqlerr
-          if sqlerr.errno == access_denied_error
-            print "#{sqlerr.error}. \nPlease provide the root password for your mysql installation\n>"
-            root_password = $stdin.gets.strip
-            grant_statement = "GRANT ALL PRIVILEGES ON #{config['database']}.* " \
-              "TO '#{config['username']}'@'localhost' " \
-              "IDENTIFIED BY '#{config['password']}' WITH GRANT OPTION;"
-            ActiveRecord::Base.establish_connection(config.merge(
-                'database' => nil, 'username' => 'root', 'password' => root_password))
-            ActiveRecord::Base.connection.create_database(config['database'], mysql_creation_options(config))
-            ActiveRecord::Base.connection.execute grant_statement
-            ActiveRecord::Base.establish_connection(config)
-          else
-            $stderr.puts sqlerr.error
-            $stderr.puts "Couldn't create database for #{config.inspect}, charset: #{config['charset'] || @charset}, collation: #{config['collation'] || @collation}"
-            $stderr.puts "(if you set the charset manually, make sure you have a matching collation)" if config['charset']
-          end
-        end
+        ActiveRecord::Base.establish_connection(config)
+        ActiveRecord::Base.connection.drop_database config['database']
+      when /^(jdbc)?sqlite/
+        require 'pathname'
+        path = Pathname.new(config['database'])
+        file = path.absolute? ? path.to_s : File.join(Rails.root, path)
+
+        FileUtils.rm(file)
       when /^(jdbc)?postgresql$/
-        @encoding = config['encoding'] || ENV['CHARSET'] || 'utf8'
-        begin
-          ActiveRecord::Base.establish_connection(config.merge('database' => 'postgres', 'schema_search_path' => 'public'))
-          ActiveRecord::Base.connection.create_database(config['database'], config.merge('encoding' => @encoding))
-          ActiveRecord::Base.establish_connection(config)
-        rescue Exception => e
-          $stderr.puts e, *(e.backtrace)
-          $stderr.puts "Couldn't create database for #{config.inspect}"
-        end
+        ActiveRecord::Base.establish_connection(config.merge('database' => 'postgres', 'schema_search_path' => 'public'))
+        ActiveRecord::Base.connection.drop_database config['database']
       end
-    else
-      $stderr.puts "#{config['database']} already exists"
     end
-  end
 
-  def self.drop_database(config)
-    case config['adapter']
-    when /^(jdbc)?mysql/
-      ActiveRecord::Base.establish_connection(config)
-      ActiveRecord::Base.connection.drop_database config['database']
-    when /^(jdbc)?sqlite/
-      require 'pathname'
-      path = Pathname.new(config['database'])
-      file = path.absolute? ? path.to_s : File.join(Rails.root, path)
+    def self.mysql_creation_options(config)
+      @charset   = ENV['CHARSET']   || 'utf8'
+      @collation = ENV['COLLATION'] || 'utf8_unicode_ci'
 
-      FileUtils.rm(file)
-    when /^(jdbc)?postgresql$/
-      ActiveRecord::Base.establish_connection(config.merge('database' => 'postgres', 'schema_search_path' => 'public'))
-      ActiveRecord::Base.connection.drop_database config['database']
+      {
+        :charset   => (config['charset']   || @charset),
+        :collation => (config['collation'] || @collation)
+      }
     end
-  end
-
-  def self.mysql_creation_options(config)
-    @charset   = ENV['CHARSET']   || 'utf8'
-    @collation = ENV['COLLATION'] || 'utf8_unicode_ci'
-
-    {
-      :charset   => (config['charset']   || @charset),
-      :collation => (config['collation'] || @collation)
-    }
   end
 end

--- a/lib/combustion/generator.rb
+++ b/lib/combustion/generator.rb
@@ -1,28 +1,30 @@
 require 'thor/group'
 
-class Combustion::Generator < Thor::Group
-  include Thor::Actions
+module Combustion
+  class Generator < Thor::Group
+    include Thor::Actions
 
-  def self.source_root
-    File.expand_path File.join(File.dirname(__FILE__), '..', '..')
-  end
+    def self.source_root
+      File.expand_path File.join(File.dirname(__FILE__), '..', '..')
+    end
 
-  def create_directories
-    empty_directory 'spec/internal'
-    empty_directory 'spec/internal/config'
-    empty_directory 'spec/internal/db'
-    empty_directory 'spec/internal/log'
-    empty_directory 'spec/internal/public'
-  end
+    def create_directories
+      empty_directory 'spec/internal'
+      empty_directory 'spec/internal/config'
+      empty_directory 'spec/internal/db'
+      empty_directory 'spec/internal/log'
+      empty_directory 'spec/internal/public'
+    end
 
-  def create_files
-    template 'templates/routes.rb',    'spec/internal/config/routes.rb'
-    template 'templates/database.yml', 'spec/internal/config/database.yml'
-    template 'templates/schema.rb',    'spec/internal/db/schema.rb'
-    template 'templates/config.ru',    'config.ru'
-    create_file                        'spec/internal/public/favicon.ico'
-    create_file                        'spec/internal/log/.gitignore' do
-      '*.log'
+    def create_files
+      template 'templates/routes.rb',    'spec/internal/config/routes.rb'
+      template 'templates/database.yml', 'spec/internal/config/database.yml'
+      template 'templates/schema.rb',    'spec/internal/db/schema.rb'
+      template 'templates/config.ru',    'config.ru'
+      create_file                        'spec/internal/public/favicon.ico'
+      create_file                        'spec/internal/log/.gitignore' do
+        '*.log'
+      end
     end
   end
 end


### PR DESCRIPTION
This allows libraries to selectively load parts of Combustion without having to load the entire thing. For example, if you wanted to use the Database class then you can just use:

``` ruby
require 'combustion/database'
```

Previously this would require:

``` ruby
require 'combustion'
require 'combustion/database'
```

As you would receive the following error message:

```
combustion/lib/combustion/database.rb:1:in `<top (required)>': uninitialized constant Combustion (NameError)
```
