### PR TITLE
Restore backwards compatibility in calling Combustion.initialize!

### DIFF
--- a/lib/combustion.rb
+++ b/lib/combustion.rb
@@ -15,7 +15,7 @@ module Combustion
   end
 
   def self.initialize!(*modules)
-    modules = Modules if modules == [:all]
+    modules = Modules if (modules == [:all]) || modules.empty?
     modules.each { |mod| require "#{mod}/railtie" }
 
     Combustion::Application.configure_for_combustion


### PR DESCRIPTION
I've been a little confused when my project appeared to be red on CI. 

I think that updates should be based on 'less surprise' principle. From this perspective - this fix is good.
