### PR TITLE
Fix failing tests while using sqlite

### DIFF
--- a/lib/combustion/database.rb
+++ b/lib/combustion/database.rb
@@ -21,7 +21,10 @@ module Combustion
         drop_database(abcs['test'])
         create_database(abcs['test'])
       when /sqlite/
-        drop_database(abcs['test'])
+        begin
+        drop_database(abcs['test']) 
+        rescue Errno::ENOENT
+        end
         create_database(abcs['test'])
       when 'sqlserver'
         test = abcs.deep_dup['test']


### PR DESCRIPTION
In some cases, running tests on CI might result in getting this error:

``` ruby
/home/travis/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/1.9.1/fileutils.rb:1406:in `unlink': No such file or directory - /home/travis/build/brain-geek/modular/spec/internal/db/combustion_test.sqlite (Errno::ENOENT)
    from /home/travis/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/1.9.1/fileutils.rb:1406:in `block in remove_file'
    from /home/travis/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/1.9.1/fileutils.rb:1411:in `platform_support'
    from /home/travis/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/1.9.1/fileutils.rb:1405:in `remove_file'
    from /home/travis/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/1.9.1/fileutils.rb:785:in `remove_file'
    from /home/travis/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/1.9.1/fileutils.rb:563:in `block in rm'
    from /home/travis/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/1.9.1/fileutils.rb:562:in `each'
    from /home/travis/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/1.9.1/fileutils.rb:562:in `rm'
    from /home/travis/.rvm/gems/ruby-1.9.3-p327/gems/combustion-0.3.3/lib/combustion/database.rb:150:in `drop_database'
    from /home/travis/.rvm/gems/ruby-1.9.3-p327/gems/combustion-0.3.3/lib/combustion/database.rb:23:in `reset_database'
    from /home/travis/.rvm/gems/ruby-1.9.3-p327/gems/combustion-0.3.3/lib/combustion/database.rb:4:in `block in setup'
    from /home/travis/.rvm/gems/ruby-1.9.3-p327/gems/activesupport-3.2.12/lib/active_support/core_ext/kernel/reporting.rb:43:in `silence_stream'
    from /home/travis/.rvm/gems/ruby-1.9.3-p327/gems/combustion-0.3.3/lib/combustion/database.rb:3:in `setup'
    from /home/travis/.rvm/gems/ruby-1.9.3-p327/gems/combustion-0.3.3/lib/combustion.rb:25:in `initialize!'
    from /home/travis/build/brain-geek/modular/spec/spec_helper.rb:7:in `<top (required)>'
    from /home/travis/build/brain-geek/modular/spec/components/base_spec.rb:1:in `require'
    from /home/travis/build/brain-geek/modular/spec/components/base_spec.rb:1:in `<top (required)>'
    from /home/travis/.rvm/gems/ruby-1.9.3-p327/gems/rspec-core-2.13.1/lib/rspec/core/configuration.rb:819:in `load'
    from /home/travis/.rvm/gems/ruby-1.9.3-p327/gems/rspec-core-2.13.1/lib/rspec/core/configuration.rb:819:in `block in load_spec_files'
    from /home/travis/.rvm/gems/ruby-1.9.3-p327/gems/rspec-core-2.13.1/lib/rspec/core/configuration.rb:819:in `each'
    from /home/travis/.rvm/gems/ruby-1.9.3-p327/gems/rspec-core-2.13.1/lib/rspec/core/configuration.rb:819:in `load_spec_files'
    from /home/travis/.rvm/gems/ruby-1.9.3-p327/gems/rspec-core-2.13.1/lib/rspec/core/command_line.rb:22:in `run'
    from /home/travis/.rvm/gems/ruby-1.9.3-p327/gems/rspec-core-2.13.1/lib/rspec/core/runner.rb:80:in `run'
    from /home/travis/.rvm/gems/ruby-1.9.3-p327/gems/rspec-core-2.13.1/lib/rspec/core/runner.rb:17:in `block in autorun'
```

This fix may not have really good coding style, but it helps.
