### PR TITLE
Use drop_database and create_database

### DIFF
--- a/lib/combustion/database.rb
+++ b/lib/combustion/database.rb
@@ -13,9 +13,8 @@ module Combustion
       abcs = ActiveRecord::Base.configurations
       case abcs['test']['adapter']
       when /mysql/
-        ActiveRecord::Base.establish_connection(:test)
-        ActiveRecord::Base.connection.recreate_database(abcs['test']['database'],
-          mysql_creation_options(abcs['test']))
+        drop_database(abcs['test']['database'])
+        create_database(abcs['test'])
         ActiveRecord::Base.establish_connection(:test)
       when /postgresql/
         ActiveRecord::Base.clear_active_connections!


### PR DESCRIPTION
Is there a reason mysql wasn't using the `drop_database` and `create_database` methods here? It was failing if the database didn't exist, but with this change, it works.
