### PR TITLE
add MIT license metadata to gemspec

### DIFF
--- a/combustion.gemspec
+++ b/combustion.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/pat/combustion'
   s.summary     = 'Elegant Rails Engine Testing'
   s.description = 'Test your Rails Engines without needing a full Rails app'
+  s.license     = 'MIT'
 
   s.rubyforge_project = 'combustion'
 


### PR DESCRIPTION
This pull request allows RubyGems.org and other tools (such as gem2rpm) to report a license for your gem.
