### PR TITLE
Remove `silence_stream` usage for rails 5 compatibility

### DIFF
--- a/lib/combustion/database.rb
+++ b/lib/combustion/database.rb
@@ -1,11 +1,9 @@
 module Combustion
   class Database
     def self.setup
-      silence_stream(STDOUT) do
-        reset_database
-        load_schema
-        migrate
-      end
+      reset_database
+      load_schema
+      migrate
     end
 
     def self.reset_database


### PR DESCRIPTION
Discussion: https://github.com/rails/rails/pull/13139
Deprecation (4.2.0): https://github.com/rails/rails/pull/13392
Removal (5.0.0): https://github.com/rails/rails/commit/481e49c64f790e46f4aff3ed539ed227d2eb46cb

I could also copy-and-paste the (now-private) `silence_stream` methods Rails is using into this class. It would look like:

```ruby
def silence_stream(stream)
  old_stream = stream.dup
  stream.reopen(RbConfig::CONFIG['host_os'] =~ /mswin|mingw/ ? 'NUL:' : '/dev/null')
  stream.sync = true
  yield
ensure
  stream.reopen(old_stream)
  old_stream.close
end
```

Personally, the extra output doesn't bother me and I don't think it's worth it to copy this code over, but that's just me.