### PR TITLE
Extract the proper parameters from the config for mysql

### DIFF
--- a/lib/combustion/database.rb
+++ b/lib/combustion/database.rb
@@ -11,7 +11,7 @@ module Combustion
       abcs = ActiveRecord::Base.configurations
       case abcs['test']['adapter']
       when /mysql/
-        drop_database(abcs['test']['database'])
+        drop_database(abcs['test'])
         create_database(abcs['test'])
         ActiveRecord::Base.establish_connection(:test)
       when /postgresql/


### PR DESCRIPTION
when dropping a database with MySQL nothing was done behind the scene cause we were not passing the right parameters to the `drop_database` function.