### PR TITLE
run Bundler.require after setting up the app's configuration

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,8 @@
+0.5.6
+* Run Bundler.require after setting up the app's configuration
+
+0.5.5
+
 0.5.4 - January 12th 2016
 * Remove silent_stream call for Rails 5.0 compatability (Bryan Ricker).
 * Fix duplicate migrations error (Semyon Pupkov).

--- a/combustion.gemspec
+++ b/combustion.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 Gem::Specification.new do |s|
   s.name        = 'combustion'
-  s.version     = '0.5.5'
+  s.version     = '0.5.6'
   s.authors     = ['Pat Allan']
   s.email       = ['pat@freelancing-gods.com']
   s.homepage    = 'https://github.com/pat/combustion'

--- a/lib/combustion.rb
+++ b/lib/combustion.rb
@@ -21,9 +21,9 @@ module Combustion
     modules = Modules if modules == [:all]
     modules.each { |mod| require "#{mod}/railtie" }
 
-    Bundler.require :default, Rails.env
-
     Combustion::Application.configure_for_combustion
+
+    Bundler.require :default, Rails.env
 
     if modules.map(&:to_s).include? 'active_record'
       Combustion::Application.config.to_prepare do


### PR DESCRIPTION
This allows code in a [before_configuration block](http://guides.rubyonrails.org/configuring.html#initialization-events) to work properly, with `Rails.root` set to the proper path (`spec/internal` in most cases).
Before `Rails.root` would return the root of the gem using combustion.

Not thoroughly tested (my gem only uses `action_controller`), opening a PR as a "FYI".