### PR TITLE
Allow to setup app with multiple db configrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ Gemfile.lock
 pkg/*
 .rvmrc
 .ruby-version
-spec/dummy/spec/internal/db/combustion_test.sqlite
+spec/dummy/spec/internal/db/*.sqlite

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,4 @@
+--color
+--tty
+--order random
+--require spec_helper.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: ruby
+
+env:
+  matrix:
+    - "DB_ADAPTER=sqlite3"
+    - "DB_ADAPTER=postgresql"
+    - "DB_ADAPTER=mysql2"
+
+rvm:
+  - 2.2.6
+  - 2.3.3
+
+script: 'bundle exec rspec'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,10 @@
 source "http://rubygems.org"
 
+group :test do
+  gem 'rails'
+  gem 'pg'
+  gem 'sqlite3'
+  gem 'mysql2'
+end
+
 gemspec

--- a/combustion.gemspec
+++ b/combustion.gemspec
@@ -20,7 +20,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'railties', '>= 3.0.0'
   s.add_runtime_dependency 'thor',  '>= 0.14.6'
 
-  s.add_development_dependency 'rails'
-  s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'rspec'
 end

--- a/lib/combustion/database.rb
+++ b/lib/combustion/database.rb
@@ -4,8 +4,8 @@ module Combustion
   end
 
   class Database
-    def self.setup(adapter = nil)
-      Combustion::Database::Reset.call adapter
+    def self.setup
+      Combustion::Database::Reset.call
       Combustion::Database::LoadSchema.call
       Combustion::Database::Migrate.call
     end

--- a/lib/combustion/databases/base.rb
+++ b/lib/combustion/databases/base.rb
@@ -8,6 +8,8 @@ class Combustion::Databases::Base
   def reset
     drop
     create
+
+    establish_connection(:test)
   end
 
   private

--- a/lib/combustion/databases/mysql.rb
+++ b/lib/combustion/databases/mysql.rb
@@ -2,9 +2,9 @@ class Combustion::Databases::MySQL < Combustion::Databases::Base
   ACCESS_DENIED_ERROR = 10145
 
   def reset
-    super
+    establish_connection(configuration.merge('database' => nil))
 
-    establish_connection :test
+    super
   end
 
   private
@@ -18,7 +18,6 @@ class Combustion::Databases::MySQL < Combustion::Databases::Base
   end
 
   def create
-    establish_connection configuration.merge('database' => nil)
     connection.create_database configuration['database'], creation_options
     establish_connection configuration
   rescue error_class => error
@@ -47,7 +46,6 @@ class Combustion::Databases::MySQL < Combustion::Databases::Base
   end
 
   def drop
-    establish_connection configuration
     connection.drop_database configuration['database']
   end
 

--- a/lib/combustion/databases/postgresql.rb
+++ b/lib/combustion/databases/postgresql.rb
@@ -1,6 +1,7 @@
 class Combustion::Databases::PostgreSQL < Combustion::Databases::Base
   def reset
     base.clear_active_connections!
+    establish_connection(postgres_configuration)
 
     super
   end
@@ -8,18 +9,18 @@ class Combustion::Databases::PostgreSQL < Combustion::Databases::Base
   private
 
   def create
-    establish_connection postgres_configuration
-    connection.create_database configuration['database'],
+    connection.create_database(
+      configuration['database'],
       configuration.merge('encoding' => encoding)
-    establish_connection configuration
+    )
+
   rescue Exception => error
     $stderr.puts error, *(error.backtrace)
     $stderr.puts "Couldn't create database for #{configuration.inspect}"
   end
 
   def drop
-    establish_connection postgres_configuration
-    connection.drop_database configuration['database']
+    connection.drop_database(configuration['database'])
   end
 
   def encoding

--- a/spec/database_spec.rb
+++ b/spec/database_spec.rb
@@ -1,17 +1,28 @@
-require 'spec_helper'
-require File.expand_path("../dummy/lib/engine.rb", __FILE__)
-
 module Combustion
   describe Database do
-    before do
+    before(:all) do
       Dir.chdir(File.expand_path('../dummy', __FILE__)) do
         Combustion.initialize! :active_record
       end
     end
 
-    it 'run migration from dummy engine' do
-      expect(ActiveRecord::Base.connection.table_exists?('dummy_table')).to eq true
+    it 'creates dummy table from migration in base database' do
+      expect(Model.connection.table_exists?('dummy_table')).to eq true
+      expect(Model.connection.table_exists?('dummy_in_another_db')).to eq false
+    end
+
+    it 'creates another dummy table from another database' do
+      expect(ModelInAnotherDb.connection.table_exists?('dummy_table')).to eq false
+      expect(ModelInAnotherDb.connection.table_exists?('dummy_in_another_db')).to eq true
+
+    end
+
+    it 'returns test databse for model with default connection' do
+      expect(Model.connection_config[:database]).to match /test/
+    end
+
+    it 'returns test_another databse for model with connection to second database' do
+      expect(ModelInAnotherDb.connection_config[:database]).to match /test_another/
     end
   end
 end
-

--- a/spec/dummy/db/migrate/20150717075543_create_dummy_test_table_in_another_db.rb
+++ b/spec/dummy/db/migrate/20150717075543_create_dummy_test_table_in_another_db.rb
@@ -1,0 +1,9 @@
+class CreateDummyTestTableInAnotherDb < ActiveRecord::Migration
+  def change
+    create_table 'dummy_in_another_db'
+  end
+
+  def connection
+    ModelInAnotherDb.connection
+  end
+end

--- a/spec/dummy/spec/internal/app/models/model.rb
+++ b/spec/dummy/spec/internal/app/models/model.rb
@@ -1,0 +1,3 @@
+class Model < ActiveRecord::Base
+  self.table_name = 'dummy_table'
+end

--- a/spec/dummy/spec/internal/app/models/model_in_another_db.rb
+++ b/spec/dummy/spec/internal/app/models/model_in_another_db.rb
@@ -1,0 +1,5 @@
+class ModelInAnotherDb < ActiveRecord::Base
+  self.table_name = 'dummy_in_another_db'
+
+  establish_connection :test_another
+end

--- a/spec/dummy/spec/internal/config/database.yml
+++ b/spec/dummy/spec/internal/config/database.yml
@@ -1,3 +1,15 @@
-test:
-  adapter:  sqlite3
-  database: db/combustion_test.sqlite
+test: &defaults
+  adapter: <%= ENV.fetch("DB_ADAPTER") %>
+  database: test
+  <% if ENV["DB_HOST"] %>
+  host: <%= ENV["DB_HOST"] %>
+  <% end %>
+
+  <% if ENV["DB_USERNAME"] %>
+  username: <%= ENV["DB_USERNAME"] %>
+  <% end %>
+
+
+test_another:
+  <<: *defaults
+  database: test_another

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
 # coding: utf-8
 require 'bundler/setup'
 require 'combustion'
+
+require File.expand_path("../dummy/lib/engine.rb", __FILE__)


### PR DESCRIPTION
Allow to setup app with multiple DB configurations  …
Combustion recreates all databases in the database.yml config.
It PR also add ability to run test for different providers in docker:
- sqlite
- postgresql
- mysql

For run tests in docker just run `make`

U can see build log here: https://travis-ci.org/artofhuman/combustion/builds/164398228
