### PR TITLE
Options for disable database reset, load_schema or migrate

### DIFF
--- a/lib/combustion.rb
+++ b/lib/combustion.rb
@@ -18,6 +18,7 @@ module Combustion
   def self.initialize!(*modules, &block)
     @@setup_environment = block if block_given?
 
+    options = modules.extract_options!
     modules = Modules if modules == [:all]
     modules.each { |mod| require "#{mod}/railtie" }
 
@@ -27,7 +28,7 @@ module Combustion
 
     if modules.map(&:to_s).include? 'active_record'
       Combustion::Application.config.to_prepare do
-        Combustion::Database.setup
+        Combustion::Database.setup(options)
       end
     end
 

--- a/lib/combustion/database.rb
+++ b/lib/combustion/database.rb
@@ -4,10 +4,10 @@ module Combustion
   end
 
   class Database
-    def self.setup
-      Combustion::Database::Reset.call
-      Combustion::Database::LoadSchema.call
-      Combustion::Database::Migrate.call
+    def self.setup(options = {})
+      Combustion::Database::Reset.call if options.fetch(:database_reset, true)
+      Combustion::Database::LoadSchema.call if options.fetch(:load_schema, true)
+      Combustion::Database::Migrate.call if options.fetch(:database_migrate, true)
     end
   end
 end


### PR DESCRIPTION
Using `database_reset: false, load_schema: false` I don't need to wait for all migrations every time I run my tests.