### PR TITLE
Avoid resetting databases for all environments, use Rails.env instead.

### DIFF
--- a/spec/database_spec.rb
+++ b/spec/database_spec.rb
@@ -20,7 +20,7 @@ module Combustion
         to eq true
     end
 
-    it "returns test databse for model with default connection" do
+    it "returns test database for model with default connection" do
       expect(Model.connection_config[:database]).to match(/test/)
     end
 


### PR DESCRIPTION
As discussed here are my changes that make it possible to run two engine (app) instances in parallel, ie. specs and a server.

In relation to https://github.com/pat/combustion/issues/82

Hope it can be merged as is, if not I can make changes accordingly.