### PR TITLE
use keyboard arguments instead of positional

### DIFF
--- a/lib/combustion/database/reset.rb
+++ b/lib/combustion/database/reset.rb
@@ -2,7 +2,7 @@
 
 class Combustion::Database::Reset
   # https://github.com/ruby/psych/pull/358/files#diff-fcdbfb11714f576f58ba9f866052bc79R322
-  RUBY_VERSION_WITH_NEW_SAFE_LOAD_METHOD_SIGNATURE = "2.6.0".freeze
+  RUBY_VERSION_WITH_NEW_SAFE_LOAD_METHOD_SIGNATURE = "2.6.0"
 
   UnsupportedDatabase = Class.new StandardError
 

--- a/lib/combustion/database/reset.rb
+++ b/lib/combustion/database/reset.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Combustion::Database::Reset
+  # https://github.com/ruby/psych/pull/358/files#diff-fcdbfb11714f576f58ba9f866052bc79R322
+  RUBY_VERSION_WITH_NEW_SAFE_LOAD_METHOD_SIGNATURE = "2.6.0".freeze
+
   UnsupportedDatabase = Class.new StandardError
 
   OPERATOR_PATTERNS = {
@@ -19,9 +22,16 @@ class Combustion::Database::Reset
   end
 
   def initialize
-    ActiveRecord::Base.configurations = YAML.safe_load(
-      ERB.new(database_yaml).result, [], [], true
-    )
+    # TODO: remove when no longer support 2.5.8
+    if RUBY_VERSION >= RUBY_VERSION_WITH_NEW_SAFE_LOAD_METHOD_SIGNATURE
+      ActiveRecord::Base.configurations = YAML.safe_load(
+        ERB.new(database_yaml).result, :aliases => true
+      )
+    else
+      ActiveRecord::Base.configurations = YAML.safe_load(
+        ERB.new(database_yaml).result, [], [], true
+      )
+    end
   end
 
   def call


### PR DESCRIPTION
Currently it throws warning when positional arguments are used:
```
/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/combustion-1.1.2/lib/combustion/database/reset.rb:22: Passing permitted_classes with the 2nd argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, permitted_classes: ...) instead.
/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/combustion-1.1.2/lib/combustion/database/reset.rb:22: Passing permitted_symbols with the 3rd argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, permitted_symbols: ...) instead.
/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/combustion-1.1.2/lib/combustion/database/reset.rb:22: Passing aliases with the 4th argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, aliases: ...) instead.
```

If we look at `Pysch` gem, they propose using keyword arguments instead.

* https://github.com/ruby/psych/blob/011dd50a19c8c2af2063fdc0f9b323eae1659af3/lib/psych.rb#L327
