### PR TITLE
Drop `git` in gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,12 +1,12 @@
 inherit_from:
   - https://gist.githubusercontent.com/pat/ba3b8ffb1901bfe5439b460943b6b019/raw/.rubocop.yml
 
-require:
-  - rubocop-packaging
-
 Bundler/OrderedGems:
   Exclude:
     - 'gemfiles/*'
+
+Gemspec/RequiredRubyVersion:
+  Enabled: false
 
 Layout/DotPosition:
   EnforcedStyle: trailing

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 inherit_from:
   - https://gist.githubusercontent.com/pat/ba3b8ffb1901bfe5439b460943b6b019/raw/.rubocop.yml
 
+require:
+  - rubocop-packaging
+
 Bundler/OrderedGems:
   Exclude:
     - 'gemfiles/*'

--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,8 @@ if RUBY_VERSION.to_f < 2.3
   gem "nio4r",    "< 2.4"
   gem "nokogiri", "< 1.10.3"
 end
+
+if RUBY_VERSION.to_f > 2.4
+  gem "rubocop",           "~> 0.92"
+  gem "rubocop-packaging", "~> 0.5"
+end

--- a/combustion.gemspec
+++ b/combustion.gemspec
@@ -10,11 +10,9 @@ Gem::Specification.new do |s|
   s.description = "Test your Rails Engines without needing a full Rails app"
   s.license     = "MIT"
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- exe/*`.split("\n").map do |file|
-    File.basename(file)
-  end
+  s.files         = Dir["{exe,lib,templates}/**/*"] + %w[LICENCE README.md]
+  s.test_files    = Dir["spec/**/*"] + %w[.rspec Appraisals Gemfile Rakefile]
+  s.executables   = ["combust"]
   s.bindir        = "exe"
   s.require_paths = ["lib"]
 

--- a/combustion.gemspec
+++ b/combustion.gemspec
@@ -28,5 +28,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rails"
   s.add_development_dependency "rspec"
   s.add_development_dependency "rubocop", "~> 0.81"
+  s.add_development_dependency "rubocop-packaging", "~> 0.5"
   s.add_development_dependency "sqlite3"
 end

--- a/combustion.gemspec
+++ b/combustion.gemspec
@@ -26,6 +26,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rails"
   s.add_development_dependency "rspec"
   s.add_development_dependency "rubocop", "~> 0.81"
-  s.add_development_dependency "rubocop-packaging", "~> 0.5"
   s.add_development_dependency "sqlite3"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "bundler/setup"
 require "combustion"
 
 if Rails::VERSION::STRING.to_f < 4.1


### PR DESCRIPTION
Hi @pat,

Thanks, again, for your wonderful work on this! 🚀 
This PR drops the usage of `git` in gemspec, as discussed in #109.

> removing git makes it easier to bundle up files that I hadn't meant to release (i.e. that I hadn't committed - experiments, in-progress features, etc).

The recent version(s) of `bundler` won't let you release your gem if you have uncommitted files, so now that risk is even lower! 😄 

Closes: #109

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>