### PR TITLE
Support future rails versions without legacy_connection_handling config

### DIFF
--- a/lib/combustion/configurations/active_record.rb
+++ b/lib/combustion/configurations/active_record.rb
@@ -4,7 +4,10 @@ class Combustion::Configurations::ActiveRecord
   def self.call(config)
     return unless defined?(ActiveRecord::Railtie)
 
-    if ActiveRecord::VERSION::MAJOR >= 7
+    ar_release_version = Gem::Version.new(ActiveRecord::VERSION::String).release
+    if ar_release_version >= Gem::Version.new("7.0") &&
+       ar_release_version < Gem::Version.new("7.1")
+       config.active_record.respond_to?(:legacy_connection_handling=)
       config.active_record.legacy_connection_handling = false
     end
 


### PR DESCRIPTION
`legacy_connection_handling=` is already missing from current rails-edge, so combustion would  presumably already fail it's own test suite on rails-edge.

Closes #123 

I decided using a "feature detection" `respond_to?` approach really was the most reliable and cleanest way to do this. Note that such a feature detection approach is already present in this very file with `return unless ::ActiveRecord.constants.include?(:MassAssignmentSecurity)` already present. 

@pat Considering that combustion already runs it's own CI on rails-edge and thus implies endorsement of the idea that this is a wise thing to do, and that this change is necessary to run combustion *at all* on rails-edge (not just to avoid deprecation warnings), perhaps you would consider doing a combustion release after all, so people can run a released combustion on rails-edge?  