### PR TITLE
Add formal version comparison helper.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,15 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0', '3.1' ]
-        bundler: [ '1.17.3', '2.1.4' ]
+        bundler: [ '1.17.3', '2.3.12' ]
         database: [ 'mysql2', 'postgresql', 'sqlite3' ]
         exclude:
           - ruby: '2.4'
-            bundler: '2.1.4'
+            bundler: '2.3.12'
           - ruby: '2.5'
-            bundler: '2.1.4'
+            bundler: '2.3.12'
           - ruby: '2.6'
-            bundler: '2.1.4'
+            bundler: '2.3.12'
           - ruby: '2.7'
             bundler: '1.17.3'
           - ruby: '3.0'
@@ -89,7 +89,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
-          bundler: 2.1.4
+          bundler: 2.3.12
           bundler-cache: true
       - name: Rubocop
         run: bundle exec rubocop

--- a/lib/combustion.rb
+++ b/lib/combustion.rb
@@ -3,6 +3,8 @@
 require "rails"
 require "active_support/dependencies"
 
+require "combustion/version_gate"
+
 module Combustion
   module Configurations
   end
@@ -28,14 +30,14 @@ module Combustion
 
   AVAILABLE_MODULES = begin
     keys = MODULES.keys
-    version = Rails.version.to_f
+    rails_gate = VersionGate.new("rails")
 
-    keys.delete(:sprockets) unless (3.1..6.1).include?(version)
-    keys.delete(:active_job) unless version >= 4.2
-    keys.delete(:action_cable) unless version >= 5.0
-    keys.delete(:active_storage) unless version >= 5.2
-    keys.delete(:action_text) unless version >= 6.0
-    keys.delete(:action_mailbox) unless version >= 6.0
+    keys.delete(:sprockets) unless rails_gate.call(">= 3.1", "<= 6.1")
+    keys.delete(:active_job) unless rails_gate.call(">= 4.2")
+    keys.delete(:action_cable) unless rails_gate.call(">= 5.0")
+    keys.delete(:active_storage) unless rails_gate.call(">= 5.2")
+    keys.delete(:action_text) unless rails_gate.call(">= 6.0")
+    keys.delete(:action_mailbox) unless rails_gate.call(">= 6.0")
 
     keys
   end.freeze

--- a/lib/combustion/application.rb
+++ b/lib/combustion/application.rb
@@ -13,16 +13,18 @@ module Combustion
       Combustion::Configurations::ActiveStorage
     ].freeze
 
-    version = Rails.version.to_f
+    rails_gate = VersionGate.new("rails")
 
     # Core Settings
     config.cache_classes               = true
     config.consider_all_requests_local = true
     config.eager_load                  = Rails.env.production?
 
-    config.secret_key_base = SecureRandom.hex if version >= 4.0
-    config.whiny_nils      = true             if version < 4.0
-    config.secret_token = Digest::SHA1.hexdigest Time.now.to_s if version < 5.2
+    config.secret_key_base = SecureRandom.hex if rails_gate.call(">= 4.0")
+    config.whiny_nils      = true             if rails_gate.call("< 4")
+    if rails_gate.call("< 5.2")
+      config.secret_token = Digest::SHA1.hexdigest Time.now.to_s
+    end
 
     # ActiveSupport Settings
     config.active_support.deprecation = :stderr

--- a/lib/combustion/configurations/active_record.rb
+++ b/lib/combustion/configurations/active_record.rb
@@ -4,7 +4,7 @@ class Combustion::Configurations::ActiveRecord
   def self.call(config)
     return unless defined?(ActiveRecord::Railtie)
 
-    if ActiveRecord::VERSION::MAJOR >= 7
+    if Combustion::VersionGate.call("activerecord", "~> 7.0.0")
       config.active_record.legacy_connection_handling = false
     end
 

--- a/lib/combustion/database/migrate.rb
+++ b/lib/combustion/database/migrate.rb
@@ -6,9 +6,11 @@ class Combustion::Database::Migrate
   end
 
   def call
-    if ActiveRecord::VERSION::STRING.to_f >= 5.2
+    ar_gate = Combustion::VersionGate.new("activerecord")
+
+    if ar_gate.call(">= 5.2")
       migration_context.migrate
-    elsif ActiveRecord::VERSION::STRING.to_f >= 3.1
+    elsif ar_gate.call(">= 3.1")
       migrator.migrate paths, nil
     else
       paths.each { |path| migrator.migrate path, nil }

--- a/lib/combustion/database/reset.rb
+++ b/lib/combustion/database/reset.rb
@@ -62,7 +62,7 @@ class Combustion::Database::Reset
   # All database configs except Rails default environments
   # that are not currently in use
   def resettable_db_configs
-    if ActiveRecord::VERSION::STRING.to_f > 6.0
+    if Combustion::VersionGate.call("activerecord", ">= 6.1")
       return resettable_db_configs_for_6_1
     end
 

--- a/lib/combustion/version_gate.rb
+++ b/lib/combustion/version_gate.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rubygems"
+
+module Combustion
+  class VersionGate
+    def self.call(name, *constraints)
+      new(name).call(*constraints)
+    end
+
+    def initialize(name)
+      @name = name
+    end
+
+    # Using matches_spec? instead of match? because the former returns true
+    # even when the spec has an appropriate _pre-release_ version.
+    def call(*constraints)
+      return false if spec.nil?
+
+      dependency(*constraints).matches_spec?(spec)
+    end
+
+    private
+
+    attr_reader :name
+
+    def dependency(*constraints)
+      Gem::Dependency.new(name, *constraints)
+    end
+
+    def spec
+      Gem.loaded_specs.fetch(name, nil)
+    end
+  end
+end

--- a/spec/database_spec.rb
+++ b/spec/database_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Combustion::Database do
   end
 
   it "returns test database for model with default connection" do
-    if ActiveRecord::VERSION::STRING.to_f > 6.0
+    if Combustion::VersionGate.call("activerecord", ">= 6.1")
       expect(Model.connection_db_config.database).to match(/combustion/)
     else
       expect(Model.connection_config[:database]).to match(/combustion/)
@@ -22,7 +22,7 @@ RSpec.describe Combustion::Database do
   end
 
   it "returns test_another for model with connection to second database" do
-    if ActiveRecord::VERSION::STRING.to_f > 6.0
+    if Combustion::VersionGate.call("activerecord", ">= 6.1")
       expect(ModelInAnotherDb.connection_db_config.database).
         to match(/test_another/)
     else

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@
 
 require "combustion"
 
-if Rails::VERSION::STRING.to_f < 4.1
+if Combustion::VersionGate.call("rails", "< 4.1")
   require "active_record"
   require "active_record/connection_adapters/mysql2_adapter"
 


### PR DESCRIPTION
Prompted by discussion in #123 and #125, though I realise this steps on @jrochkind's kind efforts, sorry! 😅

I considered whether detecting the presence of methods would be the best way forward - but given the code is extensively checking Rails/ActiveRecord versions, I opted to lean into that but with a neater syntax to leverage Rubygems/Bundler's version constraint logic rather than string-to-float wrangling. Also, it refers directly to the locked gem versions via Bundler - not something I've done before, but it seems to work well.