### PR TITLE
Set active_support cache format on Rails 7.1

### DIFF
--- a/lib/combustion/application.rb
+++ b/lib/combustion/application.rb
@@ -25,6 +25,9 @@ module Combustion
     if rails_gate.call("< 5.2")
       config.secret_token = Digest::SHA1.hexdigest Time.now.to_s
     end
+    if rails_gate.call("~> 7.1.0.alpha")
+      config.active_support.cache_format_version = 7.1
+    end
 
     # ActiveSupport Settings
     config.active_support.deprecation = :stderr


### PR DESCRIPTION
Rails 7.1 adds a deprecation warning when the version is left as the default (6.1) value here. Rails 7.0 intoduced a new format, but did not issue a warning.