### PR TITLE
Use railties for version gate

### DIFF
--- a/lib/combustion.rb
+++ b/lib/combustion.rb
@@ -30,7 +30,7 @@ module Combustion
 
   AVAILABLE_MODULES = begin
     keys = MODULES.keys
-    rails_gate = VersionGate.new("rails")
+    rails_gate = VersionGate.new("railties")
 
     keys.delete(:sprockets) unless rails_gate.call(">= 3.1", "< 7.0")
     keys.delete(:active_job) unless rails_gate.call(">= 4.2")

--- a/lib/combustion/application.rb
+++ b/lib/combustion/application.rb
@@ -13,7 +13,7 @@ module Combustion
       Combustion::Configurations::ActiveStorage
     ].freeze
 
-    rails_gate = VersionGate.new("rails")
+    rails_gate = VersionGate.new("railties")
 
     # Core Settings
     config.cache_classes               = true


### PR DESCRIPTION
Hi @pat, big thanks for this project (and for maintaining it for all of these years)!!

This PR changes the version gate to use `railties` rather than `rails` (since it's a runtime dependency and `rails` isn't).