### PR TITLE
Avoid updating Rubygems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,6 @@ jobs:
           export BUNDLER_VERSION=${{ matrix.bundler }}
           export BUNDLE_PATH=$PWD/vendor/bundle
 
-          gem update --system
-
           bundle _${{ matrix.bundler }}_ config set path $PWD/$BUNDLE_PATH
           bundle _${{ matrix.bundler }}_ install --jobs=4 --retry=3
           bundle _${{ matrix.bundler }}_ update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.6', '2.7', '3.0', '3.1', '3.2' ]
+        ruby: [ '2.6', '2.7', '3.0', '3.1', '3.2', '3.3' ]
         bundler: [ '1.17.3', '2.3.12' ]
         database: [ 'mysql2', 'postgresql', 'sqlite3' ]
         exclude:
@@ -22,6 +22,8 @@ jobs:
           - ruby: '3.1'
             bundler: '1.17.3'
           - ruby: '3.2'
+            bundler: '1.17.3'
+          - ruby: '3.3'
             bundler: '1.17.3'
 
     services:

--- a/Appraisals
+++ b/Appraisals
@@ -23,7 +23,7 @@ if RUBY_VERSION.to_f >= 2.5 && RUBY_VERSION.to_f < 3.1
   appraise "rails-6.0" do
     gem "rails", "~> 6.0.0"
     gem "mysql2", "~> 0.5.0"
-    gem "sqlite3", "~> 1.4"
+    gem "sqlite3", "~> 1.4", "< 1.5.0"
   end
 end
 
@@ -31,7 +31,7 @@ if RUBY_VERSION.to_f >= 2.5
   appraise "rails-6.1" do
     gem "rails", "~> 6.1.0"
     gem "mysql2", "~> 0.5.0"
-    gem "sqlite3", "~> 1.4"
+    gem "sqlite3", "~> 1.4", "< 1.6.0"
   end
 end
 

--- a/Appraisals
+++ b/Appraisals
@@ -42,6 +42,14 @@ if RUBY_VERSION.to_f >= 2.7
     gem "sqlite3", "~> 1.4"
   end
 
+  appraise "rails-7.1" do
+    gem "rails", "~> 7.1.2"
+    gem "mysql2", "~> 0.5.0"
+    gem "sqlite3", "~> 1.4"
+  end
+end
+
+if RUBY_VERSION.to_f >= 3.1
   appraise "rails-edge" do
     gem "rails", :git => "https://github.com/rails/rails.git", :branch => "main"
     gem "mysql2", "~> 0.5.0"


### PR DESCRIPTION
Ideally just for old Rubies, but let's just skip it for everything now.