### PR TITLE
Add support for Trilogy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         ruby: [ '2.6', '2.7', '3.0', '3.1', '3.2', '3.3' ]
         bundler: [ '1.17.3', '2.3.12' ]
-        database: [ 'mysql2', 'postgresql', 'sqlite3' ]
+        database: [ 'mysql2', 'postgresql', 'sqlite3', 'trilogy' ]
         exclude:
           - ruby: '2.6'
             bundler: '2.3.12'
@@ -25,6 +25,10 @@ jobs:
             bundler: '1.17.3'
           - ruby: '3.3'
             bundler: '1.17.3'
+          - ruby: '2.6'
+            database: 'trilogy'
+          - ruby: '2.7'
+            database: 'trilogy'
 
     services:
       postgres:

--- a/Appraisals
+++ b/Appraisals
@@ -24,6 +24,7 @@ if RUBY_VERSION.to_f >= 2.5 && RUBY_VERSION.to_f < 3.1
     gem "rails", "~> 6.0.0"
     gem "mysql2", "~> 0.5.0"
     gem "sqlite3", "~> 1.4", "< 1.5.0"
+    gem "activerecord-trilogy-adapter", "~> 3.1"
   end
 end
 
@@ -32,6 +33,7 @@ if RUBY_VERSION.to_f >= 2.5
     gem "rails", "~> 6.1.0"
     gem "mysql2", "~> 0.5.0"
     gem "sqlite3", "~> 1.4", "< 1.6.0"
+    gem "activerecord-trilogy-adapter", "~> 3.1"
   end
 end
 
@@ -40,12 +42,14 @@ if RUBY_VERSION.to_f >= 2.7
     gem "rails", "~> 7.0.1"
     gem "mysql2", "~> 0.5.0"
     gem "sqlite3", "~> 1.4"
+    gem "activerecord-trilogy-adapter", "~> 3.1"
   end
 
   appraise "rails-7.1" do
     gem "rails", "~> 7.1.2"
     gem "mysql2", "~> 0.5.0"
     gem "sqlite3", "~> 1.4"
+    gem "trilogy", "~> 2.7"
   end
 end
 
@@ -54,5 +58,6 @@ if RUBY_VERSION.to_f >= 3.1
     gem "rails", :git => "https://github.com/rails/rails.git", :branch => "main"
     gem "mysql2", "~> 0.5.0"
     gem "sqlite3", "~> 1.4"
+    gem "trilogy", "~> 2.7"
   end
 end

--- a/lib/combustion/database/reset.rb
+++ b/lib/combustion/database/reset.rb
@@ -7,7 +7,7 @@ class Combustion::Database::Reset
   UnsupportedDatabase = Class.new StandardError
 
   OPERATOR_PATTERNS = {
-    Combustion::Databases::MySQL      => [/mysql/],
+    Combustion::Databases::MySQL      => [/mysql/, /trilogy/],
     Combustion::Databases::PostgreSQL => [/postgres/, /postgis/],
     Combustion::Databases::SQLite     => [/sqlite/],
     Combustion::Databases::SQLServer  => [/sqlserver/],

--- a/lib/combustion/databases/mysql.rb
+++ b/lib/combustion/databases/mysql.rb
@@ -60,6 +60,8 @@ class Combustion::Databases::MySQL < Combustion::Databases::Base
       ArJdbcMySQL::Error
     elsif configuration[:adapter][/mysql2/] && defined?(Mysql2)
       Mysql2::Error
+    elsif configuration[:adapter][/trilogy/] && defined?(Trilogy)
+      Trilogy::Error
     else
       Mysql::Error
     end


### PR DESCRIPTION
Adds support for the Trilogy adapter, which is supported by Rails 7.1+

Relevant links

- https://github.blog/2022-08-25-introducing-trilogy-a-new-database-adapter-for-ruby-on-rails/
- https://github.com/trilogy-libraries/trilogy/tree/main/contrib/ruby
- https://github.com/trilogy-libraries/activerecord-trilogy-adapter