### PR TITLE
Load defaults for Rails 7.2+

### DIFF
--- a/lib/combustion/application.rb
+++ b/lib/combustion/application.rb
@@ -15,6 +15,10 @@ module Combustion
 
     rails_gate = VersionGate.new("railties")
 
+    if rails_gate.call(">= 7.2.0.alpha")
+      config.load_defaults Rails::VERSION::STRING.to_f
+    end
+
     # Core Settings
     config.cache_classes               = true
     config.consider_all_requests_local = true


### PR DESCRIPTION
For #138

`load_defaults` was added in Rails 5.1: https://github.com/rails/rails/pull/28469

Also, this might be considered a breaking change.