### PR TITLE
Confirming support for Ruby 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,24 +9,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4' ]
-        bundler: [ '1.17.3', '2.3.12' ]
+        ruby: [ '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '4.0' ]
         database: [ 'mysql2', 'postgresql', 'sqlite3', 'trilogy' ]
         exclude:
-          - ruby: '2.6'
-            bundler: '2.3.12'
-          - ruby: '2.7'
-            bundler: '1.17.3'
-          - ruby: '3.0'
-            bundler: '1.17.3'
-          - ruby: '3.1'
-            bundler: '1.17.3'
-          - ruby: '3.2'
-            bundler: '1.17.3'
-          - ruby: '3.3'
-            bundler: '1.17.3'
-          - ruby: '3.4'
-            bundler: '1.17.3'
           - ruby: '2.6'
             database: 'trilogy'
           - ruby: '2.7'
@@ -53,26 +38,19 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Set up ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler: ${{ matrix.bundler }}
           bundler-cache: true
-
-      - name: Set up Bundler
-        run: |
-          export BUNDLER_VERSION=${{ matrix.bundler }}
-          export BUNDLE_PATH=$PWD/vendor/bundle
-
-          bundle _${{ matrix.bundler }}_ config set path $PWD/$BUNDLE_PATH
-          bundle _${{ matrix.bundler }}_ install --jobs=4 --retry=3
-          bundle _${{ matrix.bundler }}_ update
       - name: Set up Appraisal
+        env:
+          BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle
         run: bundle exec appraisal update
       - name: Test
         env:
+          BUNDLE_PATH: ${{ github.workspace }}/vendor/bundle
           CI: "true"
           DB_ADAPTER: ${{ matrix.database }}
           DB_USERNAME: root
@@ -88,7 +66,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Set up ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/Appraisals
+++ b/Appraisals
@@ -29,7 +29,7 @@ if RUBY_VERSION.to_f >= 2.5 && RUBY_VERSION.to_f < 3.1
   end
 end
 
-if RUBY_VERSION.to_f >= 2.5
+if RUBY_VERSION.to_f >= 2.5 && RUBY_VERSION.to_f < 4.0
   appraise "rails-6.1" do
     gem "rails", "~> 6.1.0"
     gem "mysql2", "~> 0.5.0"
@@ -40,7 +40,7 @@ if RUBY_VERSION.to_f >= 2.5
   end
 end
 
-if RUBY_VERSION.to_f >= 2.7
+if RUBY_VERSION.to_f >= 3.0
   appraise "rails-7.0" do
     gem "rails", "~> 7.0.1"
     gem "mysql2", "~> 0.5.0"
@@ -72,7 +72,9 @@ if RUBY_VERSION.to_f >= 3.2
     gem "sqlite3", "~> 2.1"
     gem "trilogy", "~> 2.9"
   end
+end
 
+if RUBY_VERSION.to_f >= 3.3
   appraise "rails-edge" do
     gem "rails", :git => "https://github.com/rails/rails.git", :branch => "main"
     gem "mysql2", "~> 0.5.0"

--- a/Gemfile
+++ b/Gemfile
@@ -13,5 +13,7 @@ end
 gem "rubocop",           "~> 0.92"
 gem "rubocop-packaging", "~> 0.5"
 
-# Required for testing Rails 6.1 on MRI 3.1+
+# Gems that are no longer part of stdlib:
 gem "net-smtp" if RUBY_VERSION.to_f > 3.0
+gem "ostruct" if RUBY_VERSION.to_f > 3.4
+gem "stringio" if RUBY_VERSION.to_f > 3.1

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ end
 
 ## Compatibility
 
-The current test matrix covers MRI 2.6 to 3.4, and Rails 5.0 to 8.1. It will possibly work on older versions and other Ruby implementations as well.
+The current test matrix covers MRI 2.6 to 4.0, and Rails 5.0 to 8.1. It will possibly work on older versions and other Ruby implementations as well.
 
 You can also use Combustion with multiple versions of Rails to test compatibility across them. [Appraisal](https://github.com/thoughtbot/appraisal) is a gem that can help with this, and a good starting reference is the [Thinking Sphinx](https://github.com/pat/thinking-sphinx) test suite, which runs against [multiple versions](https://github.com/pat/thinking-sphinx/blob/develop/Appraisals) of Rails.
 

--- a/combustion.gemspec
+++ b/combustion.gemspec
@@ -37,6 +37,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pg"
   s.add_development_dependency "rails"
   s.add_development_dependency "rspec"
-  s.add_development_dependency "rubocop", "~> 0.81.0"
+  s.add_development_dependency "rubocop", "~> 0.92"
   s.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
Had to wrangle (and mostly simplify) the CI setup. No functional changes to the gem itself, so this just confirms that the gem already works with Ruby 4.0.